### PR TITLE
Fix: Allow module loaders to return something.

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -44,7 +44,9 @@ const loaders = require(path.resolve(loadersPath));
 
 Object.keys(loaders).forEach(ext => {
   const loader = loaders[ext];
-  require.extensions[`.${ext}`] = (m, filepath) => loader(filepath);
+  require.extensions[`.${ext}`] = (m, filepath) => {
+    m.exports = loader(filepath);
+  };
 })
 
 // load polyfills


### PR DESCRIPTION
Loaders were not working as expected as the returned value was not passed to the caller.
