### PR TITLE
Context should contain only the story name

### DIFF
--- a/src/test_runner/snapshot_runner.js
+++ b/src/test_runner/snapshot_runner.js
@@ -27,7 +27,7 @@ export default class SnapshotRunner {
 
     const key = story.name;
     const hasSnapshot = snapshot.has(key);
-    const context = { kind: this.kind, story };
+    const context = { kind: this.kind, story: story.name };
     const tree = story.render(context);
     const renderer = ReactTestRenderer.create(tree);
     const actual = renderer.toJSON();


### PR DESCRIPTION
The whole story was incorrectly passed into context. This was causing #17.
