### PR TITLE
Fix missing dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "babel-runtime": "^6.5.0",
     "chalk": "^1.1.3",
     "chokidar": "^1.6.0",
+    "commander": "^2.9.0",
     "jest-diff": "^15.1.0",
     "jest-snapshot": "^15.1.1",
     "jsdom": "^9.5.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   },
   "dependencies": {
     "babel-polyfill": "^6.13.0",
+    "babel-register": "^6.14.0",
     "babel-runtime": "^6.5.0",
     "chalk": "^1.1.3",
     "chokidar": "^1.6.0",


### PR DESCRIPTION
- Add missing `commander` dependency to `package.json`
  - [`src/cli.js` uses it here](https://github.com/kadirahq/storyshots/blob/v1.0.3/src/cli.js#L7)
- Add missing `babel-register` dependency to `package.json`
  - [`src/cli.js` uses it here](https://github.com/kadirahq/storyshots/blob/v1.0.3/src/cli.js#L39)

I was having trouble testing out storyshots in our application, as I didn't even get close to the finish line due to these missing packages. I tested that these should be the only missing packages required to run the CLI on a fresh project by using my test branch directly as a dependency:

```
npm i -D @kadira/storyshots@valscion/storyshots.git#9fac03c6a5b4d29725616029b58ddc7b16e10635
```

I suspect this commit was the original one where these missing dependencies were introduced: 2cebcc236f58c5638cc7e742c7e96b5b36fa93dd

In the end, I discovered that we have such a complicated webpack setup ourselves that we likely won't be able to use storyshots ourselves but will have to integrate snapshot testing to our storybook stories some other way. I'll be happy to tell more about this if you are interested, but it isn't related to these changes :smile:

This package is really promising, keep up the good work! :+1:
