### PR TITLE
Add ignore option to ignore cirtain stories or kinds by name

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -17,6 +17,7 @@ program
   .option('-i, --update-interactive [boolean]',
           'Update saved story snapshots interactively')
   .option('-g, --grep [string]', 'only test stories matching regexp')
+  .option('-i, --ignore [string]', 'ignore stories matching regexp')
   .option('-w, --watch [boolean]', 'watch file changes and rerun tests')
   .option('--polyfills [string]', 'add global polyfills')
   .option('--loaders [string]', 'add loaders')
@@ -26,7 +27,8 @@ const {
   configDir = './.storybook',
   polyfills: polyfillsPath = require.resolve('./default_config/polyfills.js'),
   loaders: loadersPath = require.resolve('./default_config/loaders.js'),
-  grep
+  grep,
+  ignore,
 } = program;
 
 const configPath = path.resolve(`${configDir}`, 'config');
@@ -70,7 +72,7 @@ async function main() {
     // We need to polyfill it for the server side.
     const channel = new EventEmitter();
     addons.setChannel(channel);
-    await runner.run(filterStorybook(storybook, grep));
+    await runner.run(filterStorybook(storybook, grep, ignore));
   } catch (e) {
     console.log(e.stack);
   }

--- a/src/tests/util.js
+++ b/src/tests/util.js
@@ -1,0 +1,79 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import { filterStorybook } from '../util';
+
+describe('filterStorybook', () => {
+  it('should filter by grep regexp', () => {
+    const storybook = [
+      {
+        kind: 'foo kind',
+        stories: [
+          { name: 'aaa aaa' },
+          { name: 'aaa aaa' },
+        ],
+      },
+      {
+        kind: 'aaaaa aaaaa',
+        stories: [
+          { name: 'aaaa aaaa' },
+          { name: 'aaa aaaa' },
+          { name: 'foo story' },
+          { name: 'aaaa' },
+        ],
+      },
+    ];
+
+    const expectedStorybook = [
+      {
+        kind: 'foo kind',
+        stories: [
+          { name: 'aaa aaa' },
+          { name: 'aaa aaa' },
+        ],
+      },
+      {
+        kind: 'aaaaa aaaaa',
+        stories: [
+          { name: 'foo story' },
+        ],
+      },
+    ];
+
+    const filteredStorybook = filterStorybook(storybook, 'foo');
+    expect(filteredStorybook).to.deep.equal(expectedStorybook);
+  });
+
+  it('should filter by ignore regexp', () => {
+    const storybook = [
+      {
+        kind: 'aaa aaaa',
+        stories: [
+          { name: 'foo bar' },
+          { name: 'foo bar' },
+        ],
+      },
+      {
+        kind: 'foo bar',
+        stories: [
+          { name: 'aaaa aaaa' },
+          { name: 'aaa aaaa' },
+          { name: 'foo story' },
+          { name: 'bar story' },
+        ],
+      },
+    ];
+
+    const expectedStorybook = [
+      {
+        kind: 'foo bar',
+        stories: [
+          { name: 'foo story' },
+          { name: 'bar story' },
+        ],
+      },
+    ];
+
+    const filteredStorybook = filterStorybook(storybook, undefined, 'aa');
+    expect(filteredStorybook).to.deep.equal(expectedStorybook);
+  });
+});


### PR DESCRIPTION
A story is only tested if it’s not ignored _and_ matches the grep.
If a kind name matched ignored regexp, all its stories are ignored.

Fixes #8
