### PR TITLE
Reset test state before each run in watch mode

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -85,7 +85,7 @@ if (program.watch) {
   });
 
   watcher.on('ready', () => {
-    console.log('storybook-snapshot-test is in watch mode.');
+    console.log('\nStoryshots is in watch mode.\n');
     watcher.on('all', () => {
       // Need to remove the require cache. Because it containes modules before
       // changes were made.

--- a/src/test_runner/index.js
+++ b/src/test_runner/index.js
@@ -73,15 +73,6 @@ export default class Runner {
     this.update = update;
     this.interactive = interactive;
 
-    this.testState = {
-      added: 0,
-      matched: 0,
-      unmatched: 0,
-      updated: 0,
-      obsolete: 0,
-      errored: 0,
-    };
-
     this.runner = new SnapshotRunner(configDir);
   }
 
@@ -90,7 +81,18 @@ export default class Runner {
     logState(result);
   }
 
-  completed() {
+  start() {
+    this.testState = {
+      added: 0,
+      matched: 0,
+      unmatched: 0,
+      updated: 0,
+      obsolete: 0,
+      errored: 0,
+    };
+  }
+
+  end() {
     logSummary(this.testState);
   }
 
@@ -99,6 +101,8 @@ export default class Runner {
       update: this.update,
       interactive: this.interactive,
     };
+
+    this.start();
 
     for (const group of storybook) {
       try {
@@ -120,6 +124,6 @@ export default class Runner {
       }
     }
 
-    this.completed();
+    this.end();
   }
 }


### PR DESCRIPTION
Previously summary displayed in watch mode included all the times the tests were run. Now it only shows stats for the last run.
