### PR TITLE
Set NODE_ENV environment variable to development if its not set.

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -10,6 +10,9 @@ import EventEmitter from 'events';
 import loadBabelConfig from '@kadira/storybook/dist/server/babel_config';
 import { filterStorybook } from './util';
 import runWithRequireContext from './require_context';
+
+process.env.NODE_ENV = process.env.NODE_ENV || 'development';
+
 const babel = require('babel-core');
 
 program


### PR DESCRIPTION
This helps storyshots to work with react-app babel preset. User can use it too.