### PR TITLE
Adding '--webpack' option to use existing Webpack configuration

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -3,10 +3,12 @@
 // This is an auto generated file with React CDK.
 // Do not modify this file.
 
-import { configure } from '@kadira/storybook';
+import { configure, getStorybook } from '@kadira/storybook';
 
 function loadStories() {
   require('../examples');
 }
 
 configure(loadStories, module);
+
+global.storybook = getStorybook()

--- a/README.md
+++ b/README.md
@@ -134,6 +134,16 @@ npm run test-storybook -- --loaders=loaders.js
 > "test-storybook": "storyshots --loaders=loaders.js"
 > ~~~
 
+### Use Webpack
+
+If you already have a Webpack configuration file you use with Storybook, you can use it in StoryShots as well. Simply run StoryShots like this:
+
+```
+storyshots --webpack
+```
+
+StoryShots will look for the webpack configuration file (`webpack.config.js`) in the config dir (provided by `--config-dir`), and run Webpack to load the stories.
+
 ### Add Window and Global Polyfills
 
 StoryShot doesn't use an actual browser, to run your code. Since your UI components may use browser features, we try to create a minimal browser environment with JSDom and with some common polyfills.

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "jsdom": "^9.5.0",
     "promptly": "^2.1.0",
     "react-test-renderer": "^15.3.1",
-    "require-hijack": "^1.2.1"
+    "require-hijack": "^1.2.1",
+    "webpack": "^1.13.3"
   }
 }

--- a/src/webpack_helper.js
+++ b/src/webpack_helper.js
@@ -1,0 +1,43 @@
+import loadConfig from '@kadira/storybook/dist/server/config';
+import getBaseConfig from '@kadira/storybook/dist/server/config/webpack.config.prod';
+import fs from 'fs';
+import webpack from 'webpack';
+import vm from 'vm';
+import path from 'path';
+
+
+export const loadAndTweakWebpackConfig = (configDir) => {
+  const config = loadConfig('PRODUCTION', getBaseConfig(), configDir);
+  config.output = {
+    path: path.resolve(configDir, './webpack'),
+    filename: 'bundle.js',
+  };
+
+  config.entry = path.resolve(configDir, 'config.js');
+  return config;
+};
+
+export const runWebpack = (config) => {
+  const compiler = webpack(config);
+
+  return new Promise((resolve, reject) => {
+    compiler.run((err) => {
+      if (err) {
+        reject(err);
+      } else {
+        const content = fs.readFileSync(path.resolve(config.output.path, config.output.filename));
+        resolve(content);
+      }
+    });
+  });
+};
+
+export const evaluateStorybookConfig = (content, polyfillsPath) => {
+  // eslint-disable-next-line  import/no-dynamic-require, global-require
+  require(path.resolve(polyfillsPath));
+
+  vm.runInThisContext(content);
+
+  const storybook = global.storybook;
+  return storybook;
+};


### PR DESCRIPTION
If you already have a Webpack configuration file you use with Storybook, you can use it in StoryShots as well. Simply run StoryShots like this:

```
storyshots --webpack
```

StoryShots will look for the webpack configuration file (`webpack.config.js`) in the config dir (provided by `--config-dir`), and run Webpack to load the stories.
