### PR TITLE
Add support for matching a story against a regex to run a story

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Now run your Jest test command. (Usually, `npm test`.) Then you can see all of y
 
 ## Options
 
-### configPath
+### `configPath`
 
 By default Storyshots assume the default config directory path for your project as below:
 
@@ -64,7 +64,7 @@ initStoryshots({
 });
 ```
 
-### suit
+### `suit`
 
 By default, we group stories inside Jest test suit called "StoryShots". You could change it like this:
 
@@ -73,3 +73,15 @@ initStoryshots({
   suit: 'MyStoryShots'
 });
 ```
+
+### `storyRegex`
+
+If you'd like to only run a subset of the stories for your snapshot tests: 
+
+```js
+initStoryshots({
+  storyRegex: /buttons/
+});
+```
+
+Here is an example of [a regex](https://regex101.com/r/vkBaAt/2) which does not pass if `"Relay"` is in the name: `/^((?!(r|R)elay).)*$/`.

--- a/src/index.js
+++ b/src/index.js
@@ -51,6 +51,10 @@ export default function testStorySnapshots (options = {}) {
     describe(suit, () => {
       describe(group.kind, () => {
         for (const story of group.stories) {
+          if (options.storyRegex && !story.name.match(options.storyRegex)) {
+            continue
+          }
+
           it(story.name, () => {
             const context = { kind: group.kind, story: story.name }
             const renderedStory = story.render(context)


### PR DESCRIPTION
Hey there, love the project! We're using storybooks [with Relay](https://github.com/alloy/relational-theory/pull/4) and want to use them [with real data](https://github.com/artsy/emission/blob/master/stories/artist_header_story.js#L14) - but I'm also really interested in the storyshots approach. 

Stubbing these components would undermine what we're doing with them, so I'd like to propose a way in which I can make storyshots only run on a subset of our stories. `storyRegex`.