### PR TITLE
Provide mock Storybook Channel to Storybook Addons for compatibility with Storybook Addon Knobs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,9 @@
 import renderer from 'react-test-renderer'
 import path from 'path'
 import readPkgUp from 'read-pkg-up'
+import addons from '@kadira/storybook-addons'
 import runWithRequireContext from './require_context'
+import createChannel from './storybook-channel-mock'
 const { describe, it, expect } = global
 
 let storybook
@@ -46,6 +48,8 @@ export default function testStorySnapshots (options = {}) {
 
   const suit = options.suit || 'Storyshots'
   const stories = storybook.getStorybook()
+
+  addons.setChannel(createChannel())
 
   for (const group of stories) {
     describe(suit, () => {

--- a/src/storybook-channel-mock.js
+++ b/src/storybook-channel-mock.js
@@ -1,0 +1,10 @@
+import Channel from '@kadira/storybook-channel'
+
+export default function createChannel () {
+  const transport = {
+    setHandler: () => {},
+    send: () => {}
+  }
+
+  return new Channel({ transport })
+}


### PR DESCRIPTION
Provide mock [Storybook Channel](https://github.com/storybooks/storybook-channel) to be able to use StoryShots with [Storybook Addon Knobs](https://github.com/storybooks/storybook-addon-knobs). The mock channel is just a noop implementation.