### PR TITLE
Initialize channel before anything else runs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,8 @@ const isRNStorybook =
   (pkg.dependencies && pkg.dependencies['@kadira/react-native-storybook'])
 
 export default function testStorySnapshots (options = {}) {
+  addons.setChannel(createChannel())
+
   if (isStorybook) {
     storybook = require.requireActual('@kadira/storybook')
     const loadBabelConfig = require('@kadira/storybook/dist/server/babel_config').default
@@ -48,8 +50,6 @@ export default function testStorySnapshots (options = {}) {
 
   const suit = options.suit || 'Storyshots'
   const stories = storybook.getStorybook()
-
-  addons.setChannel(createChannel())
 
   for (const group of stories) {
     describe(suit, () => {


### PR DESCRIPTION
I'm running into a case where the initialization of an addon is expecting a channel to exist. If the channel isn't created before `runWithRequireContext`, I'll get an error:

```
 TypeError: Cannot read property 'on' of null

      at Object.init (node_modules/storybook-addon-i18n-tools/dist/preview/index.js:24:10)
      at Object.<anonymous> (node_modules/storybook-addon-i18n-tools/preview.js:2:9)
```

Reproducible with the above addon. Note that the a listener is added onto the channel during the addon's init(). https://github.com/joscha/storybook-addon-i18n-tools/blob/master/src/preview/index.js#L9-L15

Let me know if this isn't the right change to make. I'm not super familiar with storybook addons and how they should be written, but this change helped get storyshots running for me.