### PR TITLE
Allow passing options to react-test-renderer .create() method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,7 @@ export default function testStorySnapshots (options = {}) {
           it(story.name, () => {
             const context = { kind: group.kind, story: story.name }
             const renderedStory = story.render(context)
-            const tree = renderer.create(renderedStory).toJSON()
+            const tree = renderer.create(renderedStory, options.rendererOptions).toJSON()
             expect(tree).toMatchSnapshot()
           })
         }

--- a/stories/__test__/__snapshots__/storyshots.test.js.snap
+++ b/stories/__test__/__snapshots__/storyshots.test.js.snap
@@ -70,6 +70,23 @@ exports[`Storyshots Button with text 1`] = `
 </button>
 `;
 
+exports[`Storyshots Component with ref on mount 1`] = `
+<input
+  style={
+    Object {
+      "backgroundColor": "#FFFFFF",
+      "border": "1px solid #eee",
+      "borderRadius": 3,
+      "fontSize": 15,
+      "margin": 10,
+      "padding": "3px 10px",
+      "width": "400px",
+    }
+  }
+  type="text"
+  value="This component reads its scrollWidth on load." />
+`;
+
 exports[`Storyshots Welcome to Storybook 1`] = `
 <div
   style={

--- a/stories/__test__/storyshots.test.js
+++ b/stories/__test__/storyshots.test.js
@@ -1,2 +1,10 @@
 import initStoryshots from '../../src'
-initStoryshots()
+
+function createNodeMock (element) {
+  if (element.type === 'input') {
+    return { scrollWidth: 123 }
+  }
+  return null
+}
+
+initStoryshots({ rendererOptions: { createNodeMock } })

--- a/stories/required_with_context/ComponentWithRef.js
+++ b/stories/required_with_context/ComponentWithRef.js
@@ -1,0 +1,36 @@
+import React from 'react'
+
+const inputStyles = {
+  border: '1px solid #eee',
+  borderRadius: 3,
+  backgroundColor: '#FFFFFF',
+  fontSize: 15,
+  padding: '3px 10px',
+  margin: 10,
+  width: '400px'
+}
+
+class ComponentWithRef extends React.Component {
+  componentDidMount () {
+    this.props.onLoad('scrollWidth: ' + this.ref.scrollWidth)
+  }
+  setRef (ref) {
+    this.ref = ref
+  }
+  render () {
+    return (
+      <input
+        type='text'
+        value={'This component reads its scrollWidth on load.'}
+        ref={r => this.setRef(r)}
+        style={inputStyles}
+      />
+    )
+  }
+}
+
+ComponentWithRef.propTypes = {
+  onLoad: React.PropTypes.func
+}
+
+export default ComponentWithRef

--- a/stories/required_with_context/ComponentWithRef.stories.js
+++ b/stories/required_with_context/ComponentWithRef.stories.js
@@ -1,0 +1,8 @@
+import React from 'react'
+import { storiesOf, action } from '@kadira/storybook'
+import ComponentWithRef from './ComponentWithRef'
+
+storiesOf('Component with ref', module)
+  .add('on mount', () => (
+    <ComponentWithRef onLoad={action('component mount')} />
+  ))


### PR DESCRIPTION
This PR adds the ability to pass options to the react-test-renderer `create` method, for example to allow mocking refs as per https://facebook.github.io/react/blog/2016/11/16/react-v15.4.0.html#mocking-refs-for-snapshot-testing
