### PR TITLE
Allow enzyme shallow renders

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,8 @@ import addons from '@kadira/storybook-addons'
 import runWithRequireContext from './require_context'
 import createChannel from './storybook-channel-mock'
 const { describe, it, expect } = global
+import { shallow } from 'enzyme'
+import { shallowToJson } from 'enzyme-to-json'
 
 let storybook
 let configPath
@@ -62,7 +64,8 @@ export default function testStorySnapshots (options = {}) {
           it(story.name, () => {
             const context = { kind: group.kind, story: story.name }
             const renderedStory = story.render(context)
-            const tree = renderer.create(renderedStory).toJSON()
+            const tree = options.shallowRender ? shallowToJson(shallow(renderedStory)) : renderer.create(renderedStory).toJSON()
+
             expect(tree).toMatchSnapshot()
           })
         }


### PR DESCRIPTION
This will give storyshots users the option to use shallow rendering with enzyme. 

Here's the problem with rendering the full component to json. Let's say we have the following setup:

```javascript
Component1 = () => (
  <div>
     <Component2 />
  </div>
)
``` 

If Component2 changes, both Component1 and Component2 have a test failure. Realistically, we only want Component2 to have a failure. Using Enzyme's shallow renders solves this problem