### PR TITLE
Add a `noMatchSnapshots` option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ initStoryshots({
 
 ### `storyRegex`
 
-If you'd like to only run a subset of the stories for your snapshot tests: 
+If you'd like to only run a subset of the stories for your snapshot tests:
 
 ```js
 initStoryshots({
@@ -85,3 +85,7 @@ initStoryshots({
 ```
 
 Here is an example of [a regex](https://regex101.com/r/vkBaAt/2) which does not pass if `"Relay"` is in the name: `/^((?!(r|R)elay).)*$/`.
+
+### `noMatchSnapshots`
+
+If you don't want to run snapshot tests, but instead just ensure that your stories render without error, pass `noMatchSnapshots: true`. This will "smoke" test your stories and make sure you haven't broken anything, which is appropriate early in the development process.

--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,9 @@ export default function testStorySnapshots (options = {}) {
             const context = { kind: group.kind, story: story.name }
             const renderedStory = story.render(context)
             const tree = renderer.create(renderedStory).toJSON()
-            expect(tree).toMatchSnapshot()
+            if (!options.noMatchSnapshots) {
+              expect(tree).toMatchSnapshot()
+            }
           })
         }
       })


### PR DESCRIPTION
See #81

Perhaps it would make sense to just allow passing a custom `test` function, to cover off cases like this and #76?

```js
initStoryshots({
  test(renderedStory) {
     // In my case, just render without looking at the result
     renderer.create(renderedStory).toJSON()

     // For #76, shallow render + snapshot
     const tree = shallowToJson(shallow(renderedStory))
     expect(tree).toMatchSnapshot()
  }
});
```