### PR TITLE
Changed react to a peer dependency to fix error due to multiple copies of React

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },
+  "peerDependencies": {
+    "react": "^15.4.2"
+  },
   "devDependencies": {
     "@kadira/storybook": "^2.21.0",
     "babel-cli": "^6.14.0",
@@ -29,7 +32,6 @@
   },
   "dependencies": {
     "babel-runtime": "^6.20.0",
-    "react": "^15.4.1",
     "react-test-renderer": "^15.3.1",
     "read-pkg-up": "^2.0.0"
   }


### PR DESCRIPTION
After installing Storyshots, I am seeing the following error in my Storybook app:

> addComponentAsRefTo(...): Only a ReactOwner can have refs. You might be adding a ref to a component that was not created inside a component's render method, or you have multiple copies of React loaded.

I can see `"react"` listed in the package.json dependencies, which is causing a second copy of React to be included in my Storybook app.

This PR changes React to a peer dependency, and everything works fine. 