### PR TITLE
Pass options to test renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Jest Snapshot Testing for [Storybook](https://getstorybook.io/).<br/>
 (Supports both [React](https://github.com/storybooks/react-storybook) and [React Native](https://github.com/storybooks/react-native-storybook) Storybook)
 
---- 
+---
 
 **This repo has been deprecated because it's now included in https://github.com/storybooks/storybook**
 
@@ -82,7 +82,7 @@ initStoryshots({
 
 ### `storyRegex`
 
-If you'd like to only run a subset of the stories for your snapshot tests: 
+If you'd like to only run a subset of the stories for your snapshot tests:
 
 ```js
 initStoryshots({
@@ -91,3 +91,26 @@ initStoryshots({
 ```
 
 Here is an example of [a regex](https://regex101.com/r/vkBaAt/2) which does not pass if `"Relay"` is in the name: `/^((?!(r|R)elay).)*$/`.
+
+### Mocking refs
+
+If you use refs in your components, you may encounter the error:
+
+```
+TypeError: Cannot read property '<someProperty>' of null
+```
+
+To fix this, you will need to [mock refs](https://facebook.github.io/react/blog/2016/11/16/react-v15.4.0.html#mocking-refs-for-snapshot-testing).
+
+You can pass a `createNodeMock` as an option on your story's `render` function:
+
+```js
+const createNodeMock = element => (element.type === 'input') ? { someProperty: 123 } : null
+
+const mockedRefStory = () => (
+  <ComponentWithRef onLoad={action('component mount')} />
+)
+mockedRefStory.options = { createNodeMock }
+
+storiesOf('Component with ref', module).add('on mount', mockedRefStory)
+```

--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,8 @@ export default function testStorySnapshots (options = {}) {
           it(story.name, () => {
             const context = { kind: group.kind, story: story.name }
             const renderedStory = story.render(context)
-            const createNodeMock = (story && story.render && story.render.options && story.render.options.createNodeMock) ? story.render.options.createNodeMock : null
+            const renderOptions = getRenderOptions(story)
+            const createNodeMock = (renderOptions.createNodeMock) ? renderOptions.createNodeMock : null
             const tree = renderer.create(renderedStory, { createNodeMock }).toJSON()
             expect(tree).toMatchSnapshot()
           })
@@ -71,3 +72,5 @@ export default function testStorySnapshots (options = {}) {
     })
   }
 }
+
+const getRenderOptions = story => (story && story.render && story.render.options) ? story.render.options : {}

--- a/src/index.js
+++ b/src/index.js
@@ -62,8 +62,7 @@ export default function testStorySnapshots (options = {}) {
           it(story.name, () => {
             const context = { kind: group.kind, story: story.name }
             const renderedStory = story.render(context)
-            const renderOptions = getRenderOptions(story)
-            const tree = renderer.create(renderedStory, getTestRendererOptions(renderOptions)).toJSON()
+            const tree = renderer.create(renderedStory, getTestRendererOptions(story)).toJSON()
             expect(tree).toMatchSnapshot()
           })
         }
@@ -74,4 +73,7 @@ export default function testStorySnapshots (options = {}) {
 
 const getRenderOptions = story => (story && story.render && story.render.options) ? story.render.options : {}
 
-const getTestRendererOptions = options => (options.createNodeMock) ? { createNodeMock: options.createNodeMock } : null
+const getTestRendererOptions = (
+  story,
+  options = getRenderOptions(story)
+) => (options.createNodeMock) ? { createNodeMock: options.createNodeMock } : null

--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,7 @@ export default function testStorySnapshots (options = {}) {
           it(story.name, () => {
             const context = { kind: group.kind, story: story.name }
             const renderedStory = story.render(context)
-            const tree = renderer.create(renderedStory).toJSON()
+            const tree = renderer.create(renderedStory, options.rendererOptions).toJSON()
             expect(tree).toMatchSnapshot()
           })
         }

--- a/src/index.js
+++ b/src/index.js
@@ -63,8 +63,7 @@ export default function testStorySnapshots (options = {}) {
             const context = { kind: group.kind, story: story.name }
             const renderedStory = story.render(context)
             const renderOptions = getRenderOptions(story)
-            const createNodeMock = (renderOptions.createNodeMock) ? renderOptions.createNodeMock : null
-            const tree = renderer.create(renderedStory, { createNodeMock }).toJSON()
+            const tree = renderer.create(renderedStory, getTestRendererOptions(renderOptions)).toJSON()
             expect(tree).toMatchSnapshot()
           })
         }
@@ -74,3 +73,5 @@ export default function testStorySnapshots (options = {}) {
 }
 
 const getRenderOptions = story => (story && story.render && story.render.options) ? story.render.options : {}
+
+const getTestRendererOptions = options => (options.createNodeMock) ? { createNodeMock: options.createNodeMock } : null

--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,8 @@ export default function testStorySnapshots (options = {}) {
           it(story.name, () => {
             const context = { kind: group.kind, story: story.name }
             const renderedStory = story.render(context)
-            const tree = renderer.create(renderedStory, options.rendererOptions).toJSON()
+            const createNodeMock = (story && story.render && story.render.options && story.render.options.createNodeMock) ? story.render.options.createNodeMock : null
+            const tree = renderer.create(renderedStory, { createNodeMock }).toJSON()
             expect(tree).toMatchSnapshot()
           })
         }

--- a/stories/__test__/__snapshots__/storyshots.test.js.snap
+++ b/stories/__test__/__snapshots__/storyshots.test.js.snap
@@ -70,6 +70,23 @@ exports[`Storyshots Button with text 1`] = `
 </button>
 `;
 
+exports[`Storyshots Component with ref on mount 1`] = `
+<input
+  style={
+    Object {
+      "backgroundColor": "#FFFFFF",
+      "border": "1px solid #eee",
+      "borderRadius": 3,
+      "fontSize": 15,
+      "margin": 10,
+      "padding": "3px 10px",
+      "width": "400px",
+    }
+  }
+  type="text"
+  value="This component reads its scrollWidth on load." />
+`;
+
 exports[`Storyshots Welcome to Storybook 1`] = `
 <div
   style={

--- a/stories/__test__/storyshots.test.js
+++ b/stories/__test__/storyshots.test.js
@@ -1,2 +1,10 @@
 import initStoryshots from '../../src'
-initStoryshots()
+
+function createNodeMock (element) {
+  if (element.type === 'input') {
+    return { scrollWidth: 123 }
+  }
+  return null
+}
+
+initStoryshots({ rendererOptions: { createNodeMock } })

--- a/stories/__test__/storyshots.test.js
+++ b/stories/__test__/storyshots.test.js
@@ -1,3 +1,2 @@
 import initStoryshots from '../../src'
-
 initStoryshots()

--- a/stories/__test__/storyshots.test.js
+++ b/stories/__test__/storyshots.test.js
@@ -1,10 +1,3 @@
 import initStoryshots from '../../src'
 
-function createNodeMock (element) {
-  if (element.type === 'input') {
-    return { scrollWidth: 123 }
-  }
-  return null
-}
-
-initStoryshots({ rendererOptions: { createNodeMock } })
+initStoryshots()

--- a/stories/required_with_context/ComponentWithRef.js
+++ b/stories/required_with_context/ComponentWithRef.js
@@ -1,0 +1,36 @@
+import React, { PropTypes } from 'react'
+
+const inputStyles = {
+  border: '1px solid #eee',
+  borderRadius: 3,
+  backgroundColor: '#FFFFFF',
+  fontSize: 15,
+  padding: '3px 10px',
+  margin: 10,
+  width: '400px'
+}
+
+class ComponentWithRef extends React.Component {
+  componentDidMount () {
+    this.props.onLoad(`scrollWidth: ${this.ref.scrollWidth}`)
+  }
+  setRef (ref) {
+    this.ref = ref
+  }
+  render () {
+    return (
+      <input
+        type='text'
+        value={'This component reads its scrollWidth on load.'}
+        ref={r => this.setRef(r)}
+        style={inputStyles}
+      />
+    )
+  }
+}
+
+ComponentWithRef.propTypes = {
+  onLoad: PropTypes.func
+}
+
+export default ComponentWithRef

--- a/stories/required_with_context/ComponentWithRef.stories.js
+++ b/stories/required_with_context/ComponentWithRef.stories.js
@@ -1,0 +1,7 @@
+import React from 'react'
+import { storiesOf, action } from '@kadira/storybook'
+import ComponentWithRef from './ComponentWithRef'
+
+storiesOf('Component with ref', module).add('on mount', () => (
+  <ComponentWithRef onLoad={action('component mount')} />
+))

--- a/stories/required_with_context/ComponentWithRef.stories.js
+++ b/stories/required_with_context/ComponentWithRef.stories.js
@@ -2,6 +2,11 @@ import React from 'react'
 import { storiesOf, action } from '@kadira/storybook'
 import ComponentWithRef from './ComponentWithRef'
 
-storiesOf('Component with ref', module).add('on mount', () => (
+const createNodeMock = element => (element.type === 'input') ? { scrollWidth: 123 } : null
+
+const mockedRefStory = () => (
   <ComponentWithRef onLoad={action('component mount')} />
-))
+)
+mockedRefStory.options = { createNodeMock }
+
+storiesOf('Component with ref', module).add('on mount', mockedRefStory)


### PR DESCRIPTION
# Issue:

When running storyshots with a story for a component that uses refs, it will throw a null reference error (see facebook/react#7371)

# What I did

This PR adds the ability to pass options to a story's render function. 

Specifically, a `createNodeMock` function can be passed through `story.render.options.createNodeMock` to `react-test-renderer`. This allows refs to be mocked as per https://facebook.github.io/react/blog/2016/11/16/react-v15.4.0.html#mocking-refs-for-snapshot-testing

# How to test

Run yarn test - `ComponentWithRef.stories.js` should use the `createNodeMock` function defined in `ComponentWithRef.stories.js:5` to mock its ref and not fail with a null reference error. The story for `ComponentWithRef` attempts to get the` scrollWidth` of a div when the component mounts.

# Thanks

With thanks to @jrdrg for the inspiration here: https://github.com/storybooks/storybook/pull/896

## Note

I am submitting this to the deprecated StoryShots repo as tests don't run in the [StoryShots package in the Storybook mono repo](https://github.com/storybooks/storybook/tree/master/packages/storyshots). I hope to re-submit this PR to the mono repo when 3.0 is released (or as soon as test running is fixed in the StoryShots package)